### PR TITLE
fix: import type `MarkerClusterGroupOptions` from `@types/leaflet.markercluster`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@nuxt/test-utils": "^3.15.1",
         "@nuxt/ui": "^2.20.0",
         "@types/leaflet.heat": "^0.2.4",
+        "@types/leaflet.markercluster": "^1.5.5",
         "@types/node": "^22.10.1",
         "@typescript-eslint/eslint-plugin": "^8.17.0",
         "caniuse-lite": "^1.0.30001687",
@@ -3570,6 +3571,16 @@
     },
     "node_modules/@types/leaflet.heat": {
       "version": "0.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
+    },
+    "node_modules/@types/leaflet.markercluster": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/leaflet.markercluster/-/leaflet.markercluster-1.5.5.tgz",
+      "integrity": "sha512-TkWOhSHDM1ANxmLi+uK0PjsVcjIKBr8CLV2WoF16dIdeFmC0Cj5P5axkI3C1Xsi4+ht6EU8+BfEbbqEF9icPrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@nuxt/test-utils": "^3.15.1",
     "@nuxt/ui": "^2.20.0",
     "@types/leaflet.heat": "^0.2.4",
+    "@types/leaflet.markercluster": "^1.5.5",
     "@types/node": "^22.10.1",
     "@typescript-eslint/eslint-plugin": "^8.17.0",
     "caniuse-lite": "^1.0.30001687",

--- a/src/runtime/composables/useLMarkerCluster.ts
+++ b/src/runtime/composables/useLMarkerCluster.ts
@@ -1,4 +1,4 @@
-import type { MarkerOptions, Map, Marker } from 'leaflet'
+import type { MarkerOptions, Map, Marker, MarkerClusterGroupOptions } from 'leaflet'
 
 interface MarkerProps {
   name?: string
@@ -9,14 +9,6 @@ interface MarkerProps {
    * Should be a string formatted as HTML
    */
   popup?: string
-}
-
-interface MarkerClusterGroupOptions {
-  showCoverageOnHover?: boolean
-  zoomToBoundsOnClick?: boolean
-  spiderfyOnMaxZoom?: boolean
-  removeOutsideVisibleBounds?: boolean
-  spiderLegPolylineOptions?: any
 }
 
 interface Props {


### PR DESCRIPTION
### 🔗 Linked issue

Solve #136


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It automatically imports types from `@types/leaflet.markercluster`.