### PR TITLE
fix: change option to `.donut`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -62,7 +62,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     // If leaflet.donut is enabled
-    if (options.heat) {
+    if (options.donut) {
       // Auto-import the LDonut component
       addComponent({
         name: 'LDonut',


### PR DESCRIPTION
### 🔗 Linked issue

see #271 for more 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

By checking the v2 implementation, I've seen that there is a check against the wrong option. Therefore, this option as been replaced with `.donut`.
